### PR TITLE
Support for Velocity proxy

### DIFF
--- a/blccpsapivelocity/pom.xml
+++ b/blccpsapivelocity/pom.xml
@@ -24,6 +24,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
                 <configuration>
                     <source>1.7</source>
                     <target>1.7</target>

--- a/blccpsapivelocity/pom.xml
+++ b/blccpsapivelocity/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.velocitypowered</groupId>
             <artifactId>velocity-api</artifactId>
-            <version>1.0.3-SNAPSHOT</version>
+            <version>1.0.4-SNAPSHOT</version>
             <type>jar</type>
             <scope>provided</scope>
         </dependency>

--- a/blccpsapivelocity/pom.xml
+++ b/blccpsapivelocity/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>badlionclientclickspersecondapi</artifactId>
+        <groupId>net.badlion</groupId>
+        <version>1.2.1</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>blccpsapivelocity</artifactId>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <defaultGoal>clean install</defaultGoal>
+        <finalName>badlionclientcpsapivelocity</finalName>
+        <sourceDirectory>src/main/java</sourceDirectory>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.velocitypowered</groupId>
+            <artifactId>velocity-api</artifactId>
+            <version>1.0.3-SNAPSHOT</version>
+            <type>jar</type>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <id>velocity-repo</id>
+            <url>https://repo.velocitypowered.com/snapshots/</url>
+        </repository>
+    </repositories>
+
+</project>

--- a/blccpsapivelocity/src/main/java/net/badlion/blccpsapivelocity/BlcCpsApiVelocity.java
+++ b/blccpsapivelocity/src/main/java/net/badlion/blccpsapivelocity/BlcCpsApiVelocity.java
@@ -9,10 +9,10 @@ import java.nio.file.Path;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.google.common.eventbus.Subscribe;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.inject.Inject;
+import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;

--- a/blccpsapivelocity/src/main/java/net/badlion/blccpsapivelocity/BlcCpsApiVelocity.java
+++ b/blccpsapivelocity/src/main/java/net/badlion/blccpsapivelocity/BlcCpsApiVelocity.java
@@ -24,33 +24,33 @@ import net.badlion.blccpsapivelocity.listener.PlayerListener;
 @Plugin(id = "blccpsapivelocity", name = "BadlionClientCPSAPI", version = "1.0", authors = {"Badlion"})
 public final class BlcCpsApiVelocity {
 
-	public static final Gson GSON_NON_PRETTY = new GsonBuilder().enableComplexMapKeySerialization().disableHtmlEscaping().create();
-	private static final Gson GSON_PRETTY = new GsonBuilder().enableComplexMapKeySerialization().disableHtmlEscaping().setPrettyPrinting().create();
+    public static final Gson GSON_NON_PRETTY = new GsonBuilder().enableComplexMapKeySerialization().disableHtmlEscaping().create();
+    private static final Gson GSON_PRETTY = new GsonBuilder().enableComplexMapKeySerialization().disableHtmlEscaping().setPrettyPrinting().create();
 
-	private final ProxyServer proxy;
-	private final Logger logger;
-	private final Path dataFolderPath;
-	private Conf conf;
-	private MinecraftChannelIdentifier blcCpsChannel;
+    private final ProxyServer proxy;
+    private final Logger logger;
+    private final Path dataFolderPath;
+    private Conf conf;
+    private MinecraftChannelIdentifier blcCpsChannel;
 
-	@Inject
+    @Inject
     public BlcCpsApiVelocity(ProxyServer proxy, Logger logger, @DataDirectory Path dataFolderPath) {
         this.proxy = proxy;
         this.logger = logger;
         this.dataFolderPath = dataFolderPath;
     }
 
-	@Subscribe
-	public void onProxyInitialize(ProxyInitializeEvent event) {
-	    final File dataFolder = this.dataFolderPath.toFile();
-	    
-	    if (!dataFolder.exists()) {
+    @Subscribe
+    public void onProxyInitialize(ProxyInitializeEvent event) {
+        final File dataFolder = this.dataFolderPath.toFile();
+        
+        if (!dataFolder.exists()) {
             if (!dataFolder.mkdir()) {
                 this.logger.error("Failed to create plugin directory.");
             }
         }
-	    
-	    try {
+        
+        try {
             this.conf = loadConf(new File(dataFolder, "config.json"));
 
             this.blcCpsChannel = MinecraftChannelIdentifier.create("badlion", "cps");
@@ -63,34 +63,34 @@ public final class BlcCpsApiVelocity {
             this.logger.error("Error with config for BadlionClientCPSAPI plugin.");
             e.printStackTrace();
         }
-	}
+    }
 
-	private Conf loadConf(File file) throws IOException {
+    private Conf loadConf(File file) throws IOException {
 
-		try (FileReader fileReader = new FileReader(file)) {
-			return BlcCpsApiVelocity.GSON_NON_PRETTY.fromJson(fileReader, Conf.class);
-		} catch (FileNotFoundException ex) {
-			this.logger.info("No Config Found: Saving default...");
-			Conf conf = new Conf();
-			this.saveConf(conf, file);
-			return conf;
-		}
-	}
+        try (FileReader fileReader = new FileReader(file)) {
+            return BlcCpsApiVelocity.GSON_NON_PRETTY.fromJson(fileReader, Conf.class);
+        } catch (FileNotFoundException ex) {
+            this.logger.info("No Config Found: Saving default...");
+            Conf conf = new Conf();
+            this.saveConf(conf, file);
+            return conf;
+        }
+    }
 
-	private void saveConf(Conf conf, File file) {
+    private void saveConf(Conf conf, File file) {
 
-		try (FileWriter fileWriter = new FileWriter(file)) {
-			BlcCpsApiVelocity.GSON_PRETTY.toJson(conf, fileWriter);
-		} catch (Exception ex) {
-			ex.printStackTrace();
-		}
-	}
+        try (FileWriter fileWriter = new FileWriter(file)) {
+            BlcCpsApiVelocity.GSON_PRETTY.toJson(conf, fileWriter);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+    }
 
-	public Conf getConf() {
-		return this.conf;
-	}
+    public Conf getConf() {
+        return this.conf;
+    }
 
-	public MinecraftChannelIdentifier getBlcCpsChannel() {
-	    return this.blcCpsChannel;
-	}
+    public MinecraftChannelIdentifier getBlcCpsChannel() {
+        return this.blcCpsChannel;
+    }
 }

--- a/blccpsapivelocity/src/main/java/net/badlion/blccpsapivelocity/BlcCpsApiVelocity.java
+++ b/blccpsapivelocity/src/main/java/net/badlion/blccpsapivelocity/BlcCpsApiVelocity.java
@@ -1,0 +1,96 @@
+package net.badlion.blccpsapivelocity;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.google.common.eventbus.Subscribe;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.inject.Inject;
+import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
+import com.velocitypowered.api.plugin.Plugin;
+import com.velocitypowered.api.plugin.annotation.DataDirectory;
+import com.velocitypowered.api.proxy.ProxyServer;
+import com.velocitypowered.api.proxy.messages.MinecraftChannelIdentifier;
+
+import net.badlion.blccpsapivelocity.listener.PlayerListener;
+
+@Plugin(id = "blccpsapivelocity", name = "BadlionClientCPSAPI", version = "1.0", authors = {"Badlion"})
+public final class BlcCpsApiVelocity {
+
+	public static final Gson GSON_NON_PRETTY = new GsonBuilder().enableComplexMapKeySerialization().disableHtmlEscaping().create();
+	private static final Gson GSON_PRETTY = new GsonBuilder().enableComplexMapKeySerialization().disableHtmlEscaping().setPrettyPrinting().create();
+
+	private final ProxyServer proxy;
+	private final Logger logger;
+	private final Path dataFolderPath;
+	private Conf conf;
+	private MinecraftChannelIdentifier blcCpsChannel;
+
+	@Inject
+    public BlcCpsApiVelocity(ProxyServer proxy, Logger logger, @DataDirectory Path dataFolderPath) {
+        this.proxy = proxy;
+        this.logger = logger;
+        this.dataFolderPath = dataFolderPath;
+    }
+
+	@Subscribe
+	public void onProxyInitialize(ProxyInitializeEvent event) {
+	    final File dataFolder = this.dataFolderPath.toFile();
+	    
+	    if (!dataFolder.exists()) {
+            if (!dataFolder.mkdir()) {
+                this.logger.log(Level.SEVERE, "Failed to create plugin directory.");
+            }
+        }
+	    
+	    try {
+            this.conf = loadConf(new File(dataFolder, "config.json"));
+
+            this.blcCpsChannel = MinecraftChannelIdentifier.create("blc", "cps");
+
+            // Only register the listener if the config loads successfully
+            this.proxy.getEventManager().register(this, new PlayerListener(this));
+
+            this.logger.log(Level.INFO, "Successfully setup BadlionClientCPSAPI plugin.");
+        } catch (Exception e) {
+            this.logger.log(Level.SEVERE, "Error with config for BadlionClientCPSAPI plugin.");
+            e.printStackTrace();
+        }
+	}
+
+	private Conf loadConf(File file) throws IOException {
+
+		try (FileReader fileReader = new FileReader(file)) {
+			return BlcCpsApiVelocity.GSON_NON_PRETTY.fromJson(fileReader, Conf.class);
+		} catch (FileNotFoundException ex) {
+			this.logger.log(Level.INFO, "No Config Found: Saving default...");
+			Conf conf = new Conf();
+			this.saveConf(conf, file);
+			return conf;
+		}
+	}
+
+	private void saveConf(Conf conf, File file) {
+
+		try (FileWriter fileWriter = new FileWriter(file)) {
+			BlcCpsApiVelocity.GSON_PRETTY.toJson(conf, fileWriter);
+		} catch (Exception ex) {
+			ex.printStackTrace();
+		}
+	}
+
+	public Conf getConf() {
+		return this.conf;
+	}
+
+	public MinecraftChannelIdentifier getBlcCpsChannel() {
+	    return this.blcCpsChannel;
+	}
+}

--- a/blccpsapivelocity/src/main/java/net/badlion/blccpsapivelocity/BlcCpsApiVelocity.java
+++ b/blccpsapivelocity/src/main/java/net/badlion/blccpsapivelocity/BlcCpsApiVelocity.java
@@ -53,7 +53,7 @@ public final class BlcCpsApiVelocity {
 	    try {
             this.conf = loadConf(new File(dataFolder, "config.json"));
 
-            this.blcCpsChannel = MinecraftChannelIdentifier.create("blc", "cps");
+            this.blcCpsChannel = MinecraftChannelIdentifier.create("badlion", "cps");
 
             // Only register the listener if the config loads successfully
             this.proxy.getEventManager().register(this, new PlayerListener(this));

--- a/blccpsapivelocity/src/main/java/net/badlion/blccpsapivelocity/BlcCpsApiVelocity.java
+++ b/blccpsapivelocity/src/main/java/net/badlion/blccpsapivelocity/BlcCpsApiVelocity.java
@@ -6,8 +6,8 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+
+import org.slf4j.Logger;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -46,7 +46,7 @@ public final class BlcCpsApiVelocity {
 	    
 	    if (!dataFolder.exists()) {
             if (!dataFolder.mkdir()) {
-                this.logger.log(Level.SEVERE, "Failed to create plugin directory.");
+                this.logger.error("Failed to create plugin directory.");
             }
         }
 	    
@@ -58,9 +58,9 @@ public final class BlcCpsApiVelocity {
             // Only register the listener if the config loads successfully
             this.proxy.getEventManager().register(this, new PlayerListener(this));
 
-            this.logger.log(Level.INFO, "Successfully setup BadlionClientCPSAPI plugin.");
+            this.logger.info("Successfully setup BadlionClientCPSAPI plugin.");
         } catch (Exception e) {
-            this.logger.log(Level.SEVERE, "Error with config for BadlionClientCPSAPI plugin.");
+            this.logger.error("Error with config for BadlionClientCPSAPI plugin.");
             e.printStackTrace();
         }
 	}
@@ -70,7 +70,7 @@ public final class BlcCpsApiVelocity {
 		try (FileReader fileReader = new FileReader(file)) {
 			return BlcCpsApiVelocity.GSON_NON_PRETTY.fromJson(fileReader, Conf.class);
 		} catch (FileNotFoundException ex) {
-			this.logger.log(Level.INFO, "No Config Found: Saving default...");
+			this.logger.info("No Config Found: Saving default...");
 			Conf conf = new Conf();
 			this.saveConf(conf, file);
 			return conf;

--- a/blccpsapivelocity/src/main/java/net/badlion/blccpsapivelocity/Conf.java
+++ b/blccpsapivelocity/src/main/java/net/badlion/blccpsapivelocity/Conf.java
@@ -1,0 +1,6 @@
+package net.badlion.blccpsapivelocity;
+
+public class Conf {
+	private int clicksPerSecondLimitRight = 20;
+	private int clicksPerSecondLimit = 20;
+}

--- a/blccpsapivelocity/src/main/java/net/badlion/blccpsapivelocity/listener/PlayerListener.java
+++ b/blccpsapivelocity/src/main/java/net/badlion/blccpsapivelocity/listener/PlayerListener.java
@@ -8,16 +8,16 @@ import net.badlion.blccpsapivelocity.BlcCpsApiVelocity;
 
 public class PlayerListener {
 
-	private BlcCpsApiVelocity plugin;
+    private BlcCpsApiVelocity plugin;
 
-	public PlayerListener(BlcCpsApiVelocity plugin) {
-		this.plugin = plugin;
-	}
+    public PlayerListener(BlcCpsApiVelocity plugin) {
+        this.plugin = plugin;
+    }
 
-	@Subscribe
-	public void onLogin(PostLoginEvent event) {
-		// Send the click speed limitation to players when they login to the proxy. A notification will appear on the Badlion Client so they know their CPS has been limited
-		Player player = event.getPlayer();
-		player.sendPluginMessage(this.plugin.getBlcCpsChannel(), BlcCpsApiVelocity.GSON_NON_PRETTY.toJson(this.plugin.getConf()).getBytes());
-	}
+    @Subscribe
+    public void onLogin(PostLoginEvent event) {
+        // Send the click speed limitation to players when they login to the proxy. A notification will appear on the Badlion Client so they know their CPS has been limited
+        Player player = event.getPlayer();
+        player.sendPluginMessage(this.plugin.getBlcCpsChannel(), BlcCpsApiVelocity.GSON_NON_PRETTY.toJson(this.plugin.getConf()).getBytes());
+    }
 }

--- a/blccpsapivelocity/src/main/java/net/badlion/blccpsapivelocity/listener/PlayerListener.java
+++ b/blccpsapivelocity/src/main/java/net/badlion/blccpsapivelocity/listener/PlayerListener.java
@@ -1,0 +1,23 @@
+package net.badlion.blccpsapivelocity.listener;
+
+import com.velocitypowered.api.event.Subscribe;
+import com.velocitypowered.api.event.connection.PostLoginEvent;
+import com.velocitypowered.api.proxy.Player;
+
+import net.badlion.blccpsapivelocity.BlcCpsApiVelocity;
+
+public class PlayerListener {
+
+	private BlcCpsApiVelocity plugin;
+
+	public PlayerListener(BlcCpsApiVelocity plugin) {
+		this.plugin = plugin;
+	}
+
+	@Subscribe
+	public void onLogin(PostLoginEvent event) {
+		// Send the click speed limitation to players when they login to the proxy. A notification will appear on the Badlion Client so they know their CPS has been limited
+		Player player = event.getPlayer();
+		player.sendPluginMessage(this.plugin.getBlcCpsChannel(), BlcCpsApiVelocity.GSON_NON_PRETTY.toJson(this.plugin.getConf()).getBytes());
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <version>1.2.1</version>
 
     <modules>
-    	<module>blccpsapivelocity</module>
+        <module>blccpsapivelocity</module>
         <module>blccpsapibungee</module>
         <module>blccpsapibukkit</module>
     </modules>

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
     <version>1.2.1</version>
 
     <modules>
+    	<module>blccpsapivelocity</module>
         <module>blccpsapibungee</module>
         <module>blccpsapibukkit</module>
     </modules>

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Badlion Client CPS API
 
-This repository explains how to limit the clicks per second (cps) of a Badlion Client user via a simple Bungee/Bukkit plugin.
+This repository explains how to limit the clicks per second (cps) of a Badlion Client user via a simple Velocity/Bungee/Bukkit plugin.
 
 By default there is no limitation to how fast you can click with the Badlion Client.
 
@@ -10,9 +10,9 @@ How to install the Badlion Client CPS API on your server.
 
 #### Quick Installation (for non-programmers)
 
-1. Download **either** the latest bukkit or bungee plugin from our releases (you don't need both, we recommend using the BungeeCord plugin if you are running BungeeCord): https://github.com/BadlionNetwork/BadlionClientCPSAPI/releases
+1. Download **either** the latest bukkit, bungee or velocity plugin from our releases (you don't need both, we recommend using the BungeeCord or Velocity plugin if you are running BungeeCord or Velocity): https://github.com/BadlionNetwork/BadlionClientCPSAPI/releases
 2. Place the downloaded plugin into your `plugins` directory on your server.
-3. Turn on the BungeeCord or Bukkit server and a default config will be automatically made in `plugins/BadlionClientCPSAPI/config.json`
+3. Turn on the Velocity, BungeeCord or Bukkit server and a default config will be automatically made in `plugins/BadlionClientCPSAPI/config.json`
 4. Edit the config as you see fit and reboot the server after you have finished editing the config (see below for more information).
 
 #### Do it yourself (for programmers)
@@ -20,7 +20,7 @@ How to install the Badlion Client CPS API on your server.
 1. Clone this repository
 2. Compile the plugin(s) you want to use (you only need one per Minecraft network).
 2. Place the compiled plugins from the `target` directories into your `plugins` directory on your server.
-3. Turn on the BungeeCord or Bukkit server and a default config will be automatically made in `plugins/BadlionClientCPSAPI/config.json`
+3. Turn on the Velocity, BungeeCord or Bukkit server and a default config will be automatically made in `plugins/BadlionClientCPSAPI/config.json`
 4. Edit the config as you see fit and reboot the server after you have finished editing the config (see below for more information).
 
 ### Example Config


### PR DESCRIPTION
This pull request adds support for [Velocity](https://www.velocitypowered.com/), a Minecraft server proxy with unparalleled server support, scalability, and flexibility. It's an alternative to BungeeCord, which is becoming increasingly popular. The Velocity API is somewhat similar to to that of BungeeCord, so porting was quite easy and maintaining it takes very little time. I tested this addition on my Velocity instance and everything works as expected.